### PR TITLE
Add Android test suites and instrumentation sample

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.bitchat"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.bitchat"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui:1.6.1")
+    implementation("androidx.compose.material3:material3:1.2.1")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.1")
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules (empty)

--- a/android/app/src/androidTest/java/com/example/bitchat/MainActivityTest.kt
+++ b/android/app/src/androidTest/java/com/example/bitchat/MainActivityTest.kt
@@ -1,0 +1,17 @@
+package com.example.bitchat
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertIsDisplayed
+import org.junit.Rule
+import org.junit.Test
+
+class MainActivityTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun greetingDisplayed() {
+        composeTestRule.onNodeWithText("Hello Android!").assertIsDisplayed()
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.bitchat">
+
+    <application
+        android:label="bitchat"
+        android:icon="@mipmap/ic_launcher">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/example/bitchat/BinaryProtocol.kt
+++ b/android/app/src/main/java/com/example/bitchat/BinaryProtocol.kt
@@ -1,0 +1,123 @@
+package com.example.bitchat
+
+import java.nio.ByteBuffer
+
+object SpecialRecipients {
+    val broadcast: ByteArray = ByteArray(8) { 0xFF.toByte() }
+}
+
+data class BitchatPacket(
+    val version: Byte = 1,
+    val type: Byte,
+    val senderID: ByteArray,
+    val recipientID: ByteArray? = null,
+    val timestamp: Long,
+    val payload: ByteArray,
+    val signature: ByteArray? = null,
+    val ttl: Byte
+)
+
+object BinaryProtocol {
+    private const val HEADER_SIZE = 13
+    private const val SENDER_ID_SIZE = 8
+    private const val RECIPIENT_ID_SIZE = 8
+    private const val SIGNATURE_SIZE = 64
+
+    fun encode(packet: BitchatPacket): ByteArray {
+        val hasRecipient = packet.recipientID != null
+        val hasSignature = packet.signature != null
+        val payloadLength = packet.payload.size
+
+        val bufferSize = HEADER_SIZE + SENDER_ID_SIZE +
+            (if (hasRecipient) RECIPIENT_ID_SIZE else 0) +
+            payloadLength + (if (hasSignature) SIGNATURE_SIZE else 0)
+        val buffer = ByteBuffer.allocate(bufferSize)
+
+        buffer.put(packet.version)
+        buffer.put(packet.type)
+        buffer.put(packet.ttl)
+        buffer.putLong(packet.timestamp)
+
+        var flags: Byte = 0
+        if (hasRecipient) flags = flags or 0x01
+        if (hasSignature) flags = flags or 0x02
+        buffer.put(flags)
+
+        buffer.putShort(payloadLength.toShort())
+
+        val sender = if (packet.senderID.size >= SENDER_ID_SIZE)
+            packet.senderID.copyOfRange(0, SENDER_ID_SIZE)
+        else
+            packet.senderID + ByteArray(SENDER_ID_SIZE - packet.senderID.size)
+        buffer.put(sender)
+
+        if (hasRecipient) {
+            val rec = packet.recipientID!!
+            val recipient = if (rec.size >= RECIPIENT_ID_SIZE)
+                rec.copyOfRange(0, RECIPIENT_ID_SIZE)
+            else
+                rec + ByteArray(RECIPIENT_ID_SIZE - rec.size)
+            buffer.put(recipient)
+        }
+
+        buffer.put(packet.payload)
+
+        if (hasSignature) {
+            val sig = packet.signature!!
+            val signature = if (sig.size >= SIGNATURE_SIZE)
+                sig.copyOfRange(0, SIGNATURE_SIZE)
+            else
+                sig + ByteArray(SIGNATURE_SIZE - sig.size)
+            buffer.put(signature)
+        }
+
+        return buffer.array()
+    }
+
+    fun decode(data: ByteArray): BitchatPacket? {
+        if (data.size < HEADER_SIZE + SENDER_ID_SIZE) return null
+        val buffer = ByteBuffer.wrap(data)
+        val version = buffer.get()
+        if (version.toInt() != 1) return null
+        val type = buffer.get()
+        val ttl = buffer.get()
+        val timestamp = buffer.long
+        val flags = buffer.get()
+        val hasRecipient = (flags.toInt() and 0x01) != 0
+        val hasSignature = (flags.toInt() and 0x02) != 0
+        val payloadLength = buffer.short.toInt() and 0xFFFF
+
+        val expectedSize = HEADER_SIZE + SENDER_ID_SIZE +
+            (if (hasRecipient) RECIPIENT_ID_SIZE else 0) +
+            payloadLength + (if (hasSignature) SIGNATURE_SIZE else 0)
+        if (data.size < expectedSize) return null
+
+        val senderID = ByteArray(SENDER_ID_SIZE)
+        buffer.get(senderID)
+
+        var recipientID: ByteArray? = null
+        if (hasRecipient) {
+            recipientID = ByteArray(RECIPIENT_ID_SIZE)
+            buffer.get(recipientID)
+        }
+
+        val payload = ByteArray(payloadLength)
+        buffer.get(payload)
+
+        var signature: ByteArray? = null
+        if (hasSignature) {
+            signature = ByteArray(SIGNATURE_SIZE)
+            buffer.get(signature)
+        }
+
+        return BitchatPacket(
+            type = type,
+            senderID = senderID,
+            recipientID = recipientID,
+            timestamp = timestamp,
+            payload = payload,
+            signature = signature,
+            ttl = ttl
+        )
+    }
+}

--- a/android/app/src/main/java/com/example/bitchat/EncryptionService.kt
+++ b/android/app/src/main/java/com/example/bitchat/EncryptionService.kt
@@ -1,0 +1,55 @@
+package com.example.bitchat
+
+import java.security.KeyPairGenerator
+import java.security.KeyPair
+import java.security.Signature
+import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+class EncryptionService {
+    private val signingKeyPair: KeyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
+    private val peerKeys: ConcurrentHashMap<String, SecretKey> = ConcurrentHashMap()
+
+    fun addPeerSecret(peerId: String, key: ByteArray) {
+        peerKeys[peerId] = SecretKeySpec(key, 0, key.size, "AES")
+    }
+
+    fun encrypt(data: ByteArray, peerId: String): ByteArray {
+        val key = peerKeys[peerId] ?: throw IllegalArgumentException("No key for peer")
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val iv = ByteArray(12)
+        java.security.SecureRandom().nextBytes(iv)
+        val spec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec)
+        val encrypted = cipher.doFinal(data)
+        return iv + encrypted
+    }
+
+    fun decrypt(data: ByteArray, peerId: String): ByteArray {
+        val key = peerKeys[peerId] ?: throw IllegalArgumentException("No key for peer")
+        val iv = data.copyOfRange(0, 12)
+        val enc = data.copyOfRange(12, data.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val spec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.DECRYPT_MODE, key, spec)
+        return cipher.doFinal(enc)
+    }
+
+    fun sign(data: ByteArray): ByteArray {
+        val sig = Signature.getInstance("Ed25519")
+        sig.initSign(signingKeyPair.private)
+        sig.update(data)
+        return sig.sign()
+    }
+
+    fun verify(signature: ByteArray, data: ByteArray): Boolean {
+        val sig = Signature.getInstance("Ed25519")
+        sig.initVerify(signingKeyPair.public)
+        sig.update(data)
+        return sig.verify(signature)
+    }
+}

--- a/android/app/src/main/java/com/example/bitchat/MainActivity.kt
+++ b/android/app/src/main/java/com/example/bitchat/MainActivity.kt
@@ -1,0 +1,31 @@
+package com.example.bitchat
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Greeting("Android")
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting(name: String) {
+    Text(text = "Hello $name!")
+}
+
+@Preview
+@Composable
+fun GreetingPreview() {
+    Greeting("Preview")
+}

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp" android:height="48dp" android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path android:fillColor="#FF0000" android:pathData="M0,0h48v48h-48z" />
+</vector>

--- a/android/app/src/test/java/com/example/bitchat/BinaryProtocolTest.kt
+++ b/android/app/src/test/java/com/example/bitchat/BinaryProtocolTest.kt
@@ -1,0 +1,36 @@
+package com.example.bitchat
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class BinaryProtocolTest {
+    @Test
+    fun encodeDecodePacket() {
+        val packet = BitchatPacket(
+            type = 1,
+            senderID = "sender".toByteArray(),
+            recipientID = "recipient".toByteArray(),
+            timestamp = System.currentTimeMillis(),
+            payload = "Hello".toByteArray(),
+            signature = null,
+            ttl = 5
+        )
+        val encoded = BinaryProtocol.encode(packet)
+        val decoded = BinaryProtocol.decode(encoded)
+        assertNotNull(decoded)
+        decoded!!
+        assertArrayEquals(packet.senderID.copyOf(8), decoded.senderID)
+        assertArrayEquals(packet.recipientID!!.copyOf(8), decoded.recipientID)
+        assertEquals(packet.type, decoded.type)
+        assertEquals(packet.ttl, decoded.ttl)
+        assertArrayEquals(packet.payload, decoded.payload)
+    }
+
+    @Test
+    fun decodeInvalidPacket() {
+        assertNull(BinaryProtocol.decode(ByteArray(5)))
+        val invalid = ByteArray(20)
+        invalid[0] = 2
+        assertNull(BinaryProtocol.decode(invalid))
+    }
+}

--- a/android/app/src/test/java/com/example/bitchat/EncryptionServiceTest.kt
+++ b/android/app/src/test/java/com/example/bitchat/EncryptionServiceTest.kt
@@ -1,0 +1,25 @@
+package com.example.bitchat
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class EncryptionServiceTest {
+    @Test
+    fun encryptDecrypt() {
+        val service = EncryptionService()
+        val key = ByteArray(32) { 1 }
+        service.addPeerSecret("peer", key)
+        val plain = "secret".toByteArray()
+        val encrypted = service.encrypt(plain, "peer")
+        val decrypted = service.decrypt(encrypted, "peer")
+        assertArrayEquals(plain, decrypted)
+    }
+
+    @Test
+    fun signVerify() {
+        val service = EncryptionService()
+        val data = "hello".toByteArray()
+        val sig = service.sign(data)
+        assertTrue(service.verify(sig, data))
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.2.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "bitchat-android"
+include(":app")


### PR DESCRIPTION
## Summary
- add a basic Android project skeleton
- implement `BinaryProtocol` and `EncryptionService` in Kotlin
- create unit tests for both
- provide a Compose `MainActivity` and instrumentation test

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d5170cc8331966adf8858e0cc97