### PR TITLE
Extend gitignore for Android Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,30 @@ __pycache__/
 ## Temporary files
 *.tmp
 *.temp
+# Android/Gradle
+.gradle/
+**/build/
+# Local configuration
+local.properties
+# Log files
+*.log
+# Android Studio generated files
+captures/
+.externalNativeBuild/
+.cxx/
+*.aab
+*.apk
+output-metadata.json
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+# Keystore files
+*.jks
+*.keystore
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+# Android Profiling
+*.hprof


### PR DESCRIPTION
## Summary
- ignore Gradle and Android Studio artifacts such as `.gradle/`, `*.iml`, `**/build/`, etc.

## Testing
- `swift test --enable-test-discovery` *(fails: emit-module command failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c0d4c952483319d3adfa2d9e07b0f