### PR TITLE
Implement LZ4 compression flag and tests

### DIFF
--- a/bitchat/Protocols/BinaryProtocol.swift
+++ b/bitchat/Protocols/BinaryProtocol.swift
@@ -43,6 +43,8 @@ struct BinaryProtocol {
         static let hasRecipient: UInt8 = 0x01
         static let hasSignature: UInt8 = 0x02
         static let isCompressed: UInt8 = 0x04
+        // Alias used by cross platform implementations
+        static let IS_COMPRESSED: UInt8 = isCompressed
     }
     
     // Encode BitchatPacket to binary format
@@ -81,7 +83,7 @@ struct BinaryProtocol {
             flags |= Flags.hasSignature
         }
         if isCompressed {
-            flags |= Flags.isCompressed
+            flags |= Flags.IS_COMPRESSED
         }
         data.append(flags)
         
@@ -147,7 +149,7 @@ struct BinaryProtocol {
         let flags = data[offset]; offset += 1
         let hasRecipient = (flags & Flags.hasRecipient) != 0
         let hasSignature = (flags & Flags.hasSignature) != 0
-        let isCompressed = (flags & Flags.isCompressed) != 0
+        let isCompressed = (flags & Flags.IS_COMPRESSED) != 0
         
         // Payload length
         let payloadLengthData = data[offset..<offset+2]

--- a/bitchatTests/CompressionTests.swift
+++ b/bitchatTests/CompressionTests.swift
@@ -1,0 +1,72 @@
+//
+// CompressionTests.swift
+// bitchatTests
+//
+// This is free and unencumbered software released into the public domain.
+// For more information, see <https://unlicense.org>
+//
+
+import XCTest
+@testable import bitchat
+
+final class CompressionTests: XCTestCase {
+    func testCompressionFlagAndDecoding() {
+        let payloadString = String(repeating: "A", count: 200)
+        let payload = Data(payloadString.utf8)
+        let packet = BitchatPacket(
+            type: MessageType.message.rawValue,
+            senderID: Data("sender".utf8),
+            recipientID: nil,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
+            payload: payload,
+            signature: nil,
+            ttl: 5
+        )
+
+        guard let encoded = packet.toBinaryData() else {
+            XCTFail("Failed to encode packet")
+            return
+        }
+
+        // Flags index after version (1) + type (1) + ttl (1) + timestamp (8)
+        let flagsIndex = 11
+        let flags = encoded[flagsIndex]
+        XCTAssertNotEqual(flags & BinaryProtocol.Flags.IS_COMPRESSED, 0)
+
+        guard let decoded = BitchatPacket.from(encoded) else {
+            XCTFail("Failed to decode packet")
+            return
+        }
+
+        XCTAssertEqual(decoded.payload, payload)
+    }
+
+    func testSmallPayloadNotCompressed() {
+        let payload = Data("Hello".utf8)
+        let packet = BitchatPacket(
+            type: MessageType.message.rawValue,
+            senderID: Data("sender".utf8),
+            recipientID: nil,
+            timestamp: UInt64(Date().timeIntervalSince1970 * 1000),
+            payload: payload,
+            signature: nil,
+            ttl: 5
+        )
+
+        guard let encoded = packet.toBinaryData() else {
+            XCTFail("Failed to encode packet")
+            return
+        }
+
+        let flagsIndex = 11
+        let flags = encoded[flagsIndex]
+        XCTAssertEqual(flags & BinaryProtocol.Flags.IS_COMPRESSED, 0)
+
+        guard let decoded = BitchatPacket.from(encoded) else {
+            XCTFail("Failed to decode packet")
+            return
+        }
+
+        XCTAssertEqual(decoded.payload, payload)
+    }
+}


### PR DESCRIPTION
## Summary
- add an alias `IS_COMPRESSED` constant for interoperability
- use this flag when encoding and decoding packets
- add tests verifying compression flag behaviour

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c0d3e27c88331beef666765f47265