### PR TITLE
Add SwiftPM test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,5 +19,18 @@ let package = Package(
             name: "bitchat",
             path: "bitchat"
         ),
+        .testTarget(
+            name: "bitchatTests",
+            dependencies: ["bitchat"],
+            path: "bitchatTests",
+            exclude: ["Info.plist"],
+            sources: [
+                "BinaryProtocolTests.swift",
+                "BitchatMessageTests.swift",
+                "BloomFilterTests.swift",
+                "MessagePaddingTests.swift",
+                "PasswordProtectedRoomTests.swift"
+            ]
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -151,3 +151,28 @@ The protocol is designed to be platform-agnostic. An Android client can be built
 - Bluetooth LE APIs
 - Same packet structure and encryption
 - Compatible service/characteristic UUIDs
+
+## Running Tests
+
+To execute the unit tests, use a macOS machine with Xcode and SwiftUI installed.
+
+1. Open the package in Xcode:
+
+   ```bash
+   open Package.swift
+   ```
+
+2. Choose the **bitchat** scheme and press **⌘U** to run all tests. You can also
+   run them from Terminal:
+
+   ```bash
+   xcodebuild test -scheme bitchat-Package
+   ```
+
+   Or invoke Swift Package Manager directly:
+
+   ```bash
+   swift test
+   ```
+
+   These commands require macOS because the project depends on SwiftUI.


### PR DESCRIPTION
## Summary
- add `bitchatTests` test target to `Package.swift`
- document how to run the test suite via Xcode or SwiftPM

## Testing
- `swift test --list-tests` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c1302bfe0833182aaa5f08f07b86f