### PR TITLE
Remove gradle wrapper jar reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ __pycache__/
 ## Temporary files
 *.tmp
 *.temp
+# Ignore Android Gradle wrapper jar
+android/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
## Summary
- ensure gradle wrapper jar can't be committed by ignoring it

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686c1976b14c83318dfc9a20786923d9