### PR TITLE
Add basic Android Compose implementation

### DIFF
--- a/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
@@ -1,0 +1,18 @@
+package chat.bitchat
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import chat.bitchat.service.TransportLayer
+import chat.bitchat.viewmodel.ChatViewModel
+import chat.bitchat.ui.MainScreen
+
+class MainActivity(private val transport: TransportLayer) : ComponentActivity() {
+    private val viewModel = ChatViewModel(transport)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MainScreen(viewModel)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/chat/bitchat/model/BitchatMessage.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/model/BitchatMessage.kt
@@ -1,0 +1,21 @@
+package chat.bitchat.model
+
+import java.util.Date
+import java.util.UUID
+
+data class BitchatMessage(
+    val id: String = UUID.randomUUID().toString(),
+    val sender: String,
+    val content: String,
+    val timestamp: Date = Date(),
+    val isRelay: Boolean,
+    val originalSender: String? = null,
+    val isPrivate: Boolean = false,
+    val recipientNickname: String? = null,
+    val senderPeerID: String? = null,
+    val mentions: List<String>? = null,
+    val room: String? = null,
+    val encryptedContent: ByteArray? = null,
+    val isEncrypted: Boolean = false,
+    var deliveryStatus: DeliveryStatus? = if (isPrivate) DeliveryStatus.Sending else null
+)

--- a/androidApp/src/main/kotlin/chat/bitchat/model/DeliveryStatus.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/model/DeliveryStatus.kt
@@ -1,0 +1,10 @@
+package chat.bitchat.model
+
+sealed class DeliveryStatus {
+    object Sending : DeliveryStatus()
+    object Sent : DeliveryStatus()
+    data class Delivered(val nickname: String, val at: Long) : DeliveryStatus()
+    data class Read(val nickname: String, val at: Long) : DeliveryStatus()
+    data class Failed(val reason: String) : DeliveryStatus()
+    data class PartiallyDelivered(val reached: Int, val total: Int) : DeliveryStatus()
+}

--- a/androidApp/src/main/kotlin/chat/bitchat/service/EncryptionService.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/service/EncryptionService.kt
@@ -1,0 +1,13 @@
+package chat.bitchat.service
+
+object EncryptionService {
+    fun encrypt(content: String, key: ByteArray): ByteArray {
+        // Placeholder for real encryption
+        return content.toByteArray()
+    }
+
+    fun decrypt(data: ByteArray, key: ByteArray): String {
+        // Placeholder for real decryption
+        return String(data)
+    }
+}

--- a/androidApp/src/main/kotlin/chat/bitchat/service/TransportLayer.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/service/TransportLayer.kt
@@ -1,0 +1,15 @@
+package chat.bitchat.service
+
+import chat.bitchat.model.BitchatMessage
+
+interface TransportLayer {
+    fun start()
+    fun stop()
+    fun sendMessage(message: BitchatMessage, peerId: String? = null)
+    fun setDelegate(delegate: TransportDelegate)
+}
+
+interface TransportDelegate {
+    fun onMessageReceived(message: BitchatMessage)
+    fun onPeersUpdated(peers: List<String>)
+}

--- a/androidApp/src/main/kotlin/chat/bitchat/ui/AboutScreen.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/ui/AboutScreen.kt
@@ -1,0 +1,21 @@
+package chat.bitchat.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AboutScreen() {
+    Surface(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Column {
+            Text("bitchat", style = MaterialTheme.typography.headlineMedium)
+            Text("Secure mesh chat", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/chat/bitchat/ui/MainScreen.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/ui/MainScreen.kt
@@ -1,0 +1,42 @@
+package chat.bitchat.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import chat.bitchat.viewmodel.ChatViewModel
+
+@Composable
+fun MainScreen(viewModel: ChatViewModel) {
+    var message by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(viewModel.messages) { msg ->
+                Text("${'$'}{msg.sender}: ${'$'}{msg.content}", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = message,
+                onValueChange = { message = it },
+                placeholder = { Text("Message") }
+            )
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = {
+                viewModel.sendMessage(message)
+                message = ""
+            }) {
+                Text("Send")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port core structures from `ChatViewModel` to Kotlin
- add simple Compose UI for chatting and app info
- stub encryption service and transport layer for Android

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c203604308331b5a826c98fcbf04f