### PR TITLE
Add WiFi Direct transport skeleton and improve transport selection

### DIFF
--- a/android/src/main/java/com/bitchat/transports/TransportManager.kt
+++ b/android/src/main/java/com/bitchat/transports/TransportManager.kt
@@ -19,8 +19,14 @@ class TransportManager {
     }
 
     fun sendOptimal(packet: BitchatPacket, toPeer: String?) {
-        // Simple strategy: use first available transport
-        val transport = transports.firstOrNull { it.isAvailable }
-        transport?.send(packet, toPeer)
+        // Prefer WiFi Direct when available, otherwise fall back to Bluetooth
+        val wifi = transports.firstOrNull { it.transportType == TransportType.WIFI_DIRECT && it.isAvailable }
+        val ble = transports.firstOrNull { it.transportType == TransportType.BLUETOOTH && it.isAvailable }
+
+        when {
+            wifi != null -> wifi.send(packet, toPeer)
+            ble != null -> ble.send(packet, toPeer)
+            else -> transports.firstOrNull { it.isAvailable }?.send(packet, toPeer)
+        }
     }
 }

--- a/android/src/main/java/com/bitchat/transports/WiFiDirectTransport.kt
+++ b/android/src/main/java/com/bitchat/transports/WiFiDirectTransport.kt
@@ -8,30 +8,146 @@
 
 package com.bitchat.transports
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.wifi.p2p.WifiP2pConfig
+import android.net.wifi.p2p.WifiP2pDevice
+import android.net.wifi.p2p.WifiP2pManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import com.bitchat.model.BitchatPacket
 import com.bitchat.model.PeerInfo
+import java.net.ServerSocket
+import java.net.Socket
 
 /** Placeholder implementation for future WiFi Direct transport */
-class WiFiDirectTransport : TransportProtocol {
+class WiFiDirectTransport(private val context: Context) : TransportProtocol {
     override val transportType = TransportType.WIFI_DIRECT
+
+    private val manager =
+        context.getSystemService(Context.WIFI_P2P_SERVICE) as? WifiP2pManager
+    private val channel = manager?.initialize(context, context.mainLooper, null)
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    private val peers = mutableMapOf<String, WifiP2pDevice>()
+    private var delegate: TransportDelegate? = null
+    private var receiverRegistered = false
+    private var serverJob: Job? = null
+
     override val isAvailable: Boolean
-        get() = false
+        get() = manager != null
+
     override val currentPeers: List<PeerInfo>
-        get() = emptyList()
+        get() = peers.values.map { PeerInfo(it.deviceAddress, it.deviceName) }
+
+    private val peerListListener = WifiP2pManager.PeerListListener { list ->
+        val newPeers = list.deviceList.associateBy { it.deviceAddress }
+        val lost = peers.keys - newPeers.keys
+        val gained = newPeers.keys - peers.keys
+        lost.forEach { delegate?.onPeerLost(PeerInfo(it)) }
+        gained.forEach { id ->
+            newPeers[id]?.let { dev ->
+                delegate?.onPeerDiscovered(PeerInfo(dev.deviceAddress, dev.deviceName))
+            }
+        }
+        peers.clear()
+        peers.putAll(newPeers)
+    }
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(c: Context?, intent: Intent?) {
+            when (intent?.action) {
+                WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION -> {
+                    manager?.requestPeers(channel, peerListListener)
+                }
+            }
+        }
+    }
 
     override fun startDiscovery() {
-        // TODO: Implement WiFi Direct discovery
+        if (!isAvailable || receiverRegistered) return
+
+        val filter = IntentFilter(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION)
+        context.registerReceiver(receiver, filter)
+        receiverRegistered = true
+
+        manager?.discoverPeers(channel, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() {}
+            override fun onFailure(reason: Int) {}
+        })
+
+        serverJob = scope.launch {
+            try {
+                val server = ServerSocket(8988)
+                while (true) {
+                    val socket = server.accept()
+                    val data = socket.getInputStream().readBytes()
+                    delegate?.onPacketReceived(
+                        BitchatPacket(type = 0, senderID = byteArrayOf(), payload = data),
+                        PeerInfo(socket.inetAddress.hostAddress ?: "")
+                    )
+                    socket.close()
+                }
+            } catch (_: Exception) {
+            }
+        }
     }
 
     override fun stopDiscovery() {
-        // TODO: Implement stop logic
+        if (!isAvailable) return
+
+        if (receiverRegistered) {
+            try {
+                context.unregisterReceiver(receiver)
+            } catch (_: IllegalArgumentException) {
+            }
+            receiverRegistered = false
+        }
+
+        manager?.stopPeerDiscovery(channel, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() {}
+            override fun onFailure(reason: Int) {}
+        })
+
+        serverJob?.cancel()
+        serverJob = null
+        peers.clear()
     }
 
     override fun send(packet: BitchatPacket, toPeer: String?) {
-        // TODO: Implement send over WiFi Direct
+        val targets = if (toPeer == null) peers.keys.toList() else listOf(toPeer)
+        val data = packet.payload
+
+        for (id in targets) {
+            val device = peers[id] ?: continue
+            val config = WifiP2pConfig().apply { deviceAddress = device.deviceAddress }
+            manager?.connect(channel, config, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    manager?.requestConnectionInfo(channel) { info ->
+                        val host = info.groupOwnerAddress
+                        if (host != null) {
+                            scope.launch {
+                                try {
+                                    Socket(host, 8988).use { socket ->
+                                        socket.getOutputStream().write(data)
+                                    }
+                                } catch (_: Exception) {
+                                }
+                            }
+                        }
+                    }
+                }
+
+                override fun onFailure(reason: Int) {}
+            })
+        }
     }
 
     override fun setDelegate(delegate: TransportDelegate) {
-        // No-op for now
+        this.delegate = delegate
     }
 }


### PR DESCRIPTION
## Summary
- implement peer discovery and sending logic in `WiFiDirectTransport`
- prefer WiFi Direct when sending packets if it's available

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c316966e08331a3c6202b812e4fe6