### PR TITLE
Refactor Android MainActivity init

### DIFF
--- a/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
@@ -9,10 +9,15 @@ import chat.bitchat.viewmodel.ChatViewModel
 import chat.bitchat.ui.MainScreen
 
 class MainActivity : ComponentActivity() {
-    private val transport: TransportLayer by lazy { TransportManagerLayer(this) }
-    private val viewModel by lazy { ChatViewModel(transport) }
+    private lateinit var transport: TransportLayer
+    private lateinit var viewModel: ChatViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        transport = TransportManagerLayer(this)
+        viewModel = ChatViewModel(transport)
+
         setContent {
             MainScreen(viewModel)
         }


### PR DESCRIPTION
## Summary
- update MainActivity so `TransportLayer` and `ChatViewModel` are initialized
  inside `onCreate`

## Testing
- `gradle` build not run - no instructions provided

------
https://chatgpt.com/codex/tasks/task_e_686c3af847cc8331bdfdd2b3ebd84ba6