### PR TITLE
Use EncryptionService instance in ChatViewModel

### DIFF
--- a/android/app/src/main/java/chat/bitchat/service/EncryptionService.kt
+++ b/android/app/src/main/java/chat/bitchat/service/EncryptionService.kt
@@ -1,4 +1,4 @@
-package com.example.bitchat
+package chat.bitchat.service
 
 import java.security.KeyPairGenerator
 import java.security.KeyPair

--- a/android/app/src/test/java/chat/bitchat/service/EncryptionServiceTest.kt
+++ b/android/app/src/test/java/chat/bitchat/service/EncryptionServiceTest.kt
@@ -1,4 +1,4 @@
-package com.example.bitchat
+package chat.bitchat.service
 
 import org.junit.Assert.*
 import org.junit.Test

--- a/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
+++ b/androidApp/src/main/kotlin/chat/bitchat/MainActivity.kt
@@ -7,10 +7,12 @@ import chat.bitchat.service.TransportLayer
 import chat.bitchat.service.TransportManagerLayer
 import chat.bitchat.viewmodel.ChatViewModel
 import chat.bitchat.ui.MainScreen
+import chat.bitchat.service.EncryptionService
 
 class MainActivity : ComponentActivity() {
     private val transport: TransportLayer by lazy { TransportManagerLayer(this) }
-    private val viewModel by lazy { ChatViewModel(transport) }
+    private val encryptionService by lazy { EncryptionService() }
+    private val viewModel by lazy { ChatViewModel(transport, encryptionService) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {


### PR DESCRIPTION
## Summary
- move EncryptionService into `chat.bitchat.service` package
- refactor `ChatViewModel` to depend on an `EncryptionService` instance
- update `MainActivity` to create and pass the service
- relocate unit tests to new package

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686c3af7b1908331a307efbec13f3075