### PR TITLE
Integrate Compose chat screen

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.compose.ui:ui:1.6.1")
     implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.compose.foundation:foundation:1.6.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/android/app/src/main/java/chat/bitchat/model/BitchatMessage.kt
+++ b/android/app/src/main/java/chat/bitchat/model/BitchatMessage.kt
@@ -1,0 +1,21 @@
+package chat.bitchat.model
+
+import java.util.Date
+import java.util.UUID
+
+data class BitchatMessage(
+    val id: String = UUID.randomUUID().toString(),
+    val sender: String,
+    val content: String,
+    val timestamp: Date = Date(),
+    val isRelay: Boolean,
+    val originalSender: String? = null,
+    val isPrivate: Boolean = false,
+    val recipientNickname: String? = null,
+    val senderPeerID: String? = null,
+    val mentions: List<String>? = null,
+    val room: String? = null,
+    val encryptedContent: ByteArray? = null,
+    val isEncrypted: Boolean = false,
+    var deliveryStatus: DeliveryStatus? = if (isPrivate) DeliveryStatus.Sending else null
+)

--- a/android/app/src/main/java/chat/bitchat/model/DeliveryStatus.kt
+++ b/android/app/src/main/java/chat/bitchat/model/DeliveryStatus.kt
@@ -1,0 +1,10 @@
+package chat.bitchat.model
+
+sealed class DeliveryStatus {
+    object Sending : DeliveryStatus()
+    object Sent : DeliveryStatus()
+    data class Delivered(val nickname: String, val at: Long) : DeliveryStatus()
+    data class Read(val nickname: String, val at: Long) : DeliveryStatus()
+    data class Failed(val reason: String) : DeliveryStatus()
+    data class PartiallyDelivered(val reached: Int, val total: Int) : DeliveryStatus()
+}

--- a/android/app/src/main/java/chat/bitchat/service/EncryptionService.kt
+++ b/android/app/src/main/java/chat/bitchat/service/EncryptionService.kt
@@ -1,0 +1,105 @@
+package chat.bitchat.service
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Simple AES-GCM encryption service used by the Compose demo.
+ * Keys are persisted using EncryptedSharedPreferences so that
+ * the same key can be reused across launches similar to iOS
+ * Keychain usage in the Swift implementation.
+ */
+object EncryptionService {
+
+    private const val PREF_NAME = "bitchat_encryption"
+    private const val KEY_PREFIX = "aes_"
+
+    private var prefs: SharedPreferences? = null
+
+    /**
+     * Initializes the encrypted preferences backing store. This must be called
+     * before any key management or encryption operations.
+     */
+    fun initialize(context: Context) {
+        if (prefs != null) return
+
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            PREF_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    /**
+     * Retrieve an existing AES key for the given alias or create a new
+     * random 256‑bit key if none exists.
+     */
+    fun getOrCreateKey(alias: String): ByteArray {
+        val stored = prefs?.getString(KEY_PREFIX + alias, null)
+        if (stored != null) {
+            return Base64.decode(stored, Base64.NO_WRAP)
+        }
+
+        val key = ByteArray(32)
+        SecureRandom().nextBytes(key)
+        prefs?.edit()?.putString(
+            KEY_PREFIX + alias,
+            Base64.encodeToString(key, Base64.NO_WRAP)
+        )?.apply()
+        return key
+    }
+
+    fun deleteKey(alias: String) {
+        prefs?.edit()?.remove(KEY_PREFIX + alias)?.apply()
+    }
+
+    /**
+     * Encrypt the provided string using AES/GCM with the supplied key.
+     * The returned byte array is compatible with CryptoKit's combined
+     * representation used on iOS (12 byte IV + ciphertext + 16 byte tag).
+     */
+    fun encrypt(content: String, key: ByteArray): ByteArray {
+        val iv = ByteArray(12)
+        SecureRandom().nextBytes(iv)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val secretKey = SecretKeySpec(key, KeyProperties.KEY_ALGORITHM_AES)
+        val spec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, spec)
+
+        val cipherText = cipher.doFinal(content.toByteArray(Charsets.UTF_8))
+        return iv + cipherText
+    }
+
+    /**
+     * Decrypt data that was produced by [encrypt].
+     */
+    fun decrypt(data: ByteArray, key: ByteArray): String {
+        require(data.size > 12) { "Invalid data" }
+
+        val iv = data.sliceArray(0 until 12)
+        val cipherText = data.sliceArray(12 until data.size)
+
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val secretKey = SecretKeySpec(key, KeyProperties.KEY_ALGORITHM_AES)
+        val spec = GCMParameterSpec(128, iv)
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, spec)
+
+        val plain = cipher.doFinal(cipherText)
+        return String(plain, Charsets.UTF_8)
+    }
+}

--- a/android/app/src/main/java/chat/bitchat/service/TransportLayer.kt
+++ b/android/app/src/main/java/chat/bitchat/service/TransportLayer.kt
@@ -1,0 +1,15 @@
+package chat.bitchat.service
+
+import chat.bitchat.model.BitchatMessage
+
+interface TransportLayer {
+    fun start()
+    fun stop()
+    fun sendMessage(message: BitchatMessage, peerId: String? = null)
+    fun setDelegate(delegate: TransportDelegate)
+}
+
+interface TransportDelegate {
+    fun onMessageReceived(message: BitchatMessage)
+    fun onPeersUpdated(peers: List<String>)
+}

--- a/android/app/src/main/java/chat/bitchat/service/TransportManagerLayer.kt
+++ b/android/app/src/main/java/chat/bitchat/service/TransportManagerLayer.kt
@@ -1,0 +1,101 @@
+package chat.bitchat.service
+
+import android.content.Context
+import android.bluetooth.BluetoothAdapter
+import com.bitchat.model.BitchatPacket
+import com.bitchat.model.PeerInfo
+import com.bitchat.transports.BluetoothTransport
+import com.bitchat.transports.TransportDelegate as LowLevelDelegate
+import com.bitchat.transports.TransportManager
+import chat.bitchat.model.BitchatMessage
+import bitchat.BitchatMessage as CommonMessage
+
+class TransportManagerLayer(private val context: Context) : TransportLayer, LowLevelDelegate {
+    private val manager = TransportManager()
+    private val bluetooth = BluetoothTransport(context)
+    private val peers = mutableSetOf<String>()
+    private var delegate: TransportDelegate? = null
+    private val senderId: ByteArray =
+        BluetoothAdapter.getDefaultAdapter()?.address?.toByteArray() ?: ByteArray(0)
+
+    init {
+        manager.registerTransport(bluetooth)
+    }
+
+    override fun start() {
+        bluetooth.setDelegate(this)
+        bluetooth.startDiscovery()
+    }
+
+    override fun stop() {
+        bluetooth.stopDiscovery()
+    }
+
+    override fun sendMessage(message: BitchatMessage, peerId: String?) {
+        val common = message.toCommon()
+        val payload = common.toBinaryPayload() ?: return
+        val packet = BitchatPacket(
+            type = 0x04,
+            senderID = senderId,
+            recipientID = peerId?.toByteArray(),
+            payload = payload,
+            ttl = 7
+        )
+        manager.sendOptimal(packet, peerId)
+    }
+
+    override fun setDelegate(delegate: TransportDelegate) {
+        this.delegate = delegate
+    }
+
+    // Low level delegate
+    override fun onPeerDiscovered(peer: PeerInfo) {
+        peers.add(peer.id)
+        delegate?.onPeersUpdated(peers.toList())
+    }
+
+    override fun onPeerLost(peer: PeerInfo) {
+        peers.remove(peer.id)
+        delegate?.onPeersUpdated(peers.toList())
+    }
+
+    override fun onPacketReceived(packet: BitchatPacket, fromPeer: PeerInfo?) {
+        val common = CommonMessage.fromBinaryPayload(packet.payload) ?: return
+        delegate?.onMessageReceived(common.toAppModel())
+    }
+
+    // Conversion helpers
+    private fun BitchatMessage.toCommon(): CommonMessage = CommonMessage(
+        id = id,
+        sender = sender,
+        content = content,
+        timestamp = timestamp,
+        isRelay = isRelay,
+        originalSender = originalSender,
+        isPrivate = isPrivate,
+        recipientNickname = recipientNickname,
+        senderPeerID = senderPeerID,
+        mentions = mentions,
+        room = room,
+        encryptedContent = encryptedContent,
+        isEncrypted = isEncrypted,
+        deliveryStatus = deliveryStatus?.let { null }
+    )
+
+    private fun CommonMessage.toAppModel(): BitchatMessage = BitchatMessage(
+        id = id,
+        sender = sender,
+        content = content,
+        timestamp = timestamp,
+        isRelay = isRelay,
+        originalSender = originalSender,
+        isPrivate = isPrivate,
+        recipientNickname = recipientNickname,
+        senderPeerID = senderPeerID,
+        mentions = mentions,
+        room = room,
+        encryptedContent = encryptedContent,
+        isEncrypted = isEncrypted,
+        deliveryStatus = deliveryStatus
+    )
+}

--- a/android/app/src/main/java/chat/bitchat/ui/AboutScreen.kt
+++ b/android/app/src/main/java/chat/bitchat/ui/AboutScreen.kt
@@ -1,0 +1,21 @@
+package chat.bitchat.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun AboutScreen() {
+    Surface(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Column {
+            Text("bitchat", style = MaterialTheme.typography.headlineMedium)
+            Text("Secure mesh chat", style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}

--- a/android/app/src/main/java/chat/bitchat/ui/MainScreen.kt
+++ b/android/app/src/main/java/chat/bitchat/ui/MainScreen.kt
@@ -1,0 +1,42 @@
+package chat.bitchat.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import chat.bitchat.viewmodel.ChatViewModel
+
+@Composable
+fun MainScreen(viewModel: ChatViewModel) {
+    var message by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(viewModel.messages) { msg ->
+                Text("${'$'}{msg.sender}: ${'$'}{msg.content}", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            TextField(
+                modifier = Modifier.weight(1f),
+                value = message,
+                onValueChange = { message = it },
+                placeholder = { Text("Message") }
+            )
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = {
+                viewModel.sendMessage(message)
+                message = ""
+            }) {
+                Text("Send")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/example/bitchat/MainActivity.kt
+++ b/android/app/src/main/java/com/example/bitchat/MainActivity.kt
@@ -3,29 +3,28 @@ package com.example.bitchat
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import chat.bitchat.service.TransportLayer
+import chat.bitchat.service.TransportManagerLayer
+import chat.bitchat.service.EncryptionService
+import chat.bitchat.viewmodel.ChatViewModel
+import chat.bitchat.ui.MainScreen
 
 class MainActivity : ComponentActivity() {
+    private lateinit var transport: TransportLayer
+    private lateinit var viewModel: ChatViewModel
+    private lateinit var encryptionKey: ByteArray
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        EncryptionService.initialize(this)
+        encryptionKey = EncryptionService.getOrCreateKey("default")
+
+        transport = TransportManagerLayer(this)
+        viewModel = ChatViewModel(transport, encryptionKey)
+
         setContent {
-            MaterialTheme {
-                Greeting("Android")
-            }
+            MainScreen(viewModel)
         }
     }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview
-@Composable
-fun GreetingPreview() {
-    Greeting("Preview")
 }


### PR DESCRIPTION
## Summary
- replace the template `Greeting` activity with the real chat screen
- copy chat UI/VM and services from androidApp
- hook up encryption and transport layers
- add dependencies for lifecycle, foundation, and security-crypto

## Testing
- `./gradlew tasks` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686c44f3a190833198008af0f2cbc14a