### PR TITLE
Add androidApp module with Compose

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,4 @@
 rootProject.name = "bitchat-android"
 include(":app")
+include(":androidApp")
+project(":androidApp").projectDir = file("../androidApp")

--- a/androidApp/build.gradle
+++ b/androidApp/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "chat.bitchat"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "chat.bitchat"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+
+    sourceSets["main"].java.srcDirs(
+        "src/main/kotlin",
+        "../android/src/main/java",
+        "../android/app/src/main/java",
+        "../kotlin"
+    )
+    sourceSets["main"].manifest.srcFile("src/main/AndroidManifest.xml")
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.ui:ui:1.6.1")
+    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("androidx.lifecycle:lifecycle-viewmodel:2.7.0")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.1")
+}

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="chat.bitchat">
+
+    <application android:label="bitchat">
+        <activity android:name=".MainActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
## Summary
- keep `androidApp` as a separate Android module
- add `build.gradle` and manifest for the Compose demo
- include `androidApp` in the Gradle settings

## Testing
- `./run_tests.sh`
- `gradle :androidApp:tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_686c44f1a4f88331bc9fd9812084c307